### PR TITLE
ESLint line ending rule fix & style fixes.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,11 @@ module.exports = {
       jsx: true,
     },
   },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
   rules: {
     // Indentation rule
     indent: 0,
@@ -23,7 +28,7 @@ module.exports = {
     '@typescript-eslint/ban-types': 0,
 
     // Force windows linebreak styles
-    'linebreak-style': [2, 'windows'],
+    'linebreak-style': [2, 'unix'],
 
     // Force semicolons
     semi: [2, 'always'],

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -6,8 +6,12 @@
   "name": "Cascading Lists",
   "description": "Extension allows to define cascading behavior for picklists in work item form.",
   "public": true,
-  "categories": ["Azure Boards"],
-  "tags": ["Cascading Picklists"],
+  "categories": [
+    "Azure Boards"
+  ],
+  "tags": [
+    "Cascading Picklists"
+  ],
   "icons": {
     "default": "images/icon-default.png",
     "large": "images/icon-large.png"
@@ -29,13 +33,18 @@
     "type": "git",
     "url": "https://github.com/microsoft/azure-devops-extension-cascading-picklist"
   },
-  "scopes": ["vso.work", "vso.work_write"],
+  "scopes": [
+    "vso.work",
+    "vso.work_write"
+  ],
   "contributions": [
     {
       "id": "cascading-lists-wit-observer",
       "type": "ms.vss-work-web.work-item-notifications",
       "description": "Observer modifies behavior of a work item form to support cascading picklists.",
-      "targets": ["ms.vss-work-web.work-item-form"],
+      "targets": [
+        "ms.vss-work-web.work-item-form"
+      ],
       "properties": {
         "name": "Cascading Lists Observer",
         "uri": "/dist/observer.html"
@@ -45,7 +54,9 @@
       "id": "cascading-lists-config-hub",
       "type": "ms.vss-web.hub",
       "description": "Configuration hub for a cascading lists",
-      "targets": ["ms.vss-web.project-admin-hub-group"],
+      "targets": [
+        "ms.vss-web.project-admin-hub-group"
+      ],
       "properties": {
         "name": "Cascading Lists",
         "order": 1,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postbuild": "npm run package",
     "package": "tfx extension create --manifest-globs azure-devops-extension.json",
     "gallery-publish": "tfx extension publish --rev-version",
-    "clean": "rimraf ./dist && rimraf ./*.vsix"
+    "clean": "rimraf ./dist && rimraf ./*.vsix",
+    "lint": "eslint ."
   },
   "dependencies": {
     "azure-devops-extension-api": "^1.152.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const webpack = require('webpack');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');


### PR DESCRIPTION
PR changes linebreak style in eslint configuration to unix style in order to be uniform and compatible with different operating systems. no-var-requires rule disabled for webpack config file, because it can't use ES6 imports syntax.