### PR TITLE
Config disappear possible fix

### DIFF
--- a/src/common/manifest.service.ts
+++ b/src/common/manifest.service.ts
@@ -40,12 +40,6 @@ class ManifestService {
   public async updateManifest(manifest: IManifest): Promise<IManifest> {
     return this.configurationStorage.setConfiguration(manifest);
   }
-
-  public async createDefaultManifest(): Promise<IManifest> {
-    return this.configurationStorage.setConfiguration(
-      Object.assign({}, ManifestService.defaultManifest)
-    );
-  }
 }
 
 class ManifestValidationService {

--- a/src/common/manifest.service.ts
+++ b/src/common/manifest.service.ts
@@ -24,6 +24,11 @@ interface IManifestValidationError {
 class ManifestService {
   private configurationStorage: ConfigurationStorage;
 
+  public static defaultManifest: IManifest = Object.freeze({
+    version: '1',
+    cascades: {},
+  });
+
   public constructor(projectId: string) {
     this.configurationStorage = new ConfigurationStorage(ConfigurationType.Manifest, projectId);
   }
@@ -37,10 +42,9 @@ class ManifestService {
   }
 
   public async createDefaultManifest(): Promise<IManifest> {
-    return this.configurationStorage.setConfiguration({
-      version: 1,
-      cascades: {},
-    });
+    return this.configurationStorage.setConfiguration(
+      Object.assign({}, ManifestService.defaultManifest)
+    );
   }
 }
 

--- a/src/confighub/hooks/configstorage.ts
+++ b/src/confighub/hooks/configstorage.ts
@@ -84,7 +84,7 @@ function useConfigurationStorage(): [
       const manifestService = new ManifestService(project.id);
       let manifest = await manifestService.getManifest();
       if (manifest == null) {
-        manifest = await manifestService.createDefaultManifest();
+        manifest = Object.assign({}, ManifestService.defaultManifest);
       }
 
       saveDraft(JSON.stringify(manifest, null, 2));

--- a/src/observer/index.ts
+++ b/src/observer/index.ts
@@ -27,7 +27,7 @@ SDK.init({
     const manifestService = new ManifestService(project.id);
     let manifest = await manifestService.getManifest();
     if (manifest == null) {
-      manifest = await manifestService.createDefaultManifest();
+      manifest = Object.assign({}, ManifestService.defaultManifest);
     }
     const cascadingService = new CascadingFieldsService(workItemFormService, manifest.cascades);
 


### PR DESCRIPTION
This pull request is a possible fix for a #29.

Previous behavior was to force rewrite config to a default value if an extension was not able to get the current config. Possibly, due to small network failure, timeouts or other connection issues, the config was failing to retrieve and that was triggering the overwriting.

This pull request changes behavior to replace overwriting in favor of using hardcoded default config when it does not exist and without writing it to extension storage that may override existing value. 