### PR TITLE
Bump version to 0.1.16. Remove Azure DevOps Server from manifest

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,12 +2,16 @@
   "manifestVersion": 1.0,
   "id": "cascading-picklists-extension",
   "publisher": "ms-devlabs",
-  "version": "0.1.14",
+  "version": "0.1.16",
   "name": "Cascading Lists",
   "description": "Extension allows to define cascading behavior for picklists in work item form.",
   "public": true,
-  "categories": ["Azure Boards"],
-  "tags": ["Cascading Picklists"],
+  "categories": [
+    "Azure Boards"
+  ],
+  "tags": [
+    "Cascading Picklists"
+  ],
   "icons": {
     "default": "images/icon-default.png",
     "large": "images/icon-large.png"
@@ -22,20 +26,25 @@
   },
   "targets": [
     {
-      "id": "Microsoft.VisualStudio.Services"
+      "id": "Microsoft.VisualStudio.Services.Cloud"
     }
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/azure-devops-extension-cascading-picklist"
   },
-  "scopes": ["vso.work", "vso.work_write"],
+  "scopes": [
+    "vso.work",
+    "vso.work_write"
+  ],
   "contributions": [
     {
       "id": "cascading-lists-wit-observer",
       "type": "ms.vss-work-web.work-item-notifications",
       "description": "Observer modifies behavior of a work item form to support cascading picklists.",
-      "targets": ["ms.vss-work-web.work-item-form"],
+      "targets": [
+        "ms.vss-work-web.work-item-form"
+      ],
       "properties": {
         "name": "Cascading Lists Observer",
         "uri": "/dist/observer.html"
@@ -45,7 +54,9 @@
       "id": "cascading-lists-config-hub",
       "type": "ms.vss-web.hub",
       "description": "Configuration hub for a cascading lists",
-      "targets": ["ms.vss-web.project-admin-hub-group"],
+      "targets": [
+        "ms.vss-web.project-admin-hub-group"
+      ],
       "properties": {
         "name": "Cascading Lists",
         "order": 1,


### PR DESCRIPTION
Because extension is not compatible with Azure DevOps Server instances, we need to remove "Azure DevOps Server" from "Works with" block.