### PR TITLE
Adding support for organization level cascading with project level override

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1.0,
   "id": "cascading-picklists-extension",
   "publisher": "ms-devlabs",
-  "version": "0.1.17",
+  "version": "0.1.16",
   "name": "Cascading Lists",
   "description": "Extension allows to define cascading behavior for picklists in work item form.",
   "public": true,

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1.0,
   "id": "cascading-picklists-extension",
   "publisher": "ms-devlabs",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "name": "Cascading Lists",
   "description": "Extension allows to define cascading behavior for picklists in work item form.",
   "public": true,
@@ -61,6 +61,19 @@
         "name": "Cascading Lists",
         "order": 1,
         "uri": "/dist/confighub.html"
+      }
+    },
+    {
+      "id": "cascading-lists-org-config-hub",
+      "type": "ms.vss-web.hub",
+      "description": "Configuration hub for a cascading lists",
+      "targets": [
+        "ms.vss-web.collection-admin-hub-group"
+      ],
+      "properties": {
+        "name": "Cascading Lists",
+        "order": 1,
+        "uri": "/dist/confighub.html?orglevel=1"
       }
     }
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/types": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
@@ -2318,8 +2326,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2340,14 +2347,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2362,20 +2367,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2492,8 +2494,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2505,7 +2506,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2520,7 +2520,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2528,14 +2527,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2554,7 +2551,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2635,8 +2631,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2648,7 +2643,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2734,8 +2728,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2771,7 +2764,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2791,7 +2783,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2835,14 +2826,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3031,6 +3020,19 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3040,6 +3042,14 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "homedir-polyfill": {
@@ -3817,6 +3827,15 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mini-create-react-context": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz",
+      "integrity": "sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -4383,6 +4402,21 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -4733,6 +4767,37 @@
         "prop-types": "^15.7.2"
       }
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -4758,6 +4823,11 @@
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -4880,6 +4950,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -5568,6 +5643,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -5985,6 +6070,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
       "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vm-browserify": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-monaco-editor": "^0.26.2",
+    "react-router-dom": "^5.2.0",
     "styled-components": "^4.3.1"
   },
   "devDependencies": {

--- a/src/common/cascading.service.ts
+++ b/src/common/cascading.service.ts
@@ -155,7 +155,7 @@ class CascadeValidationService {
 
     if (this.cachedFields == null) {
       const witRestClient = await getClient(WorkItemTrackingRestClient);
-      const fields = await witRestClient.getFields(project.id);
+      const fields = (project) ? await witRestClient.getFields(project.id) : await witRestClient.getFields();
       this.cachedFields = fields;
     }
     const fieldList = this.cachedFields.map(field => field.referenceName);

--- a/src/common/storage.service.ts
+++ b/src/common/storage.service.ts
@@ -7,7 +7,7 @@ enum ScopeType {
 }
 
 enum ConfigurationType {
-  Manifest = 'manifest',
+  Manifest = 'manifest'
 }
 
 class StorageService {
@@ -29,7 +29,7 @@ class StorageService {
     }
     return this.dataService;
   }
-
+  
   public async getData(): Promise<Object> {
     const dataService = await this.getDataService();
     const dataManager = await dataService.getExtensionDataManager(
@@ -56,9 +56,15 @@ class StorageService {
 class ConfigurationStorage {
   private storageService: StorageService;
 
-  public constructor(configurationType: ConfigurationType, projectId: string) {
+  public constructor(configurationType: ConfigurationType, projectId: string = null) {
+    let key: string = `${configurationType}`;
+
+    if(projectId != null && projectId != "")
+    {
+      key = `${key}|${projectId}`;
+    }
     this.storageService = new StorageService(
-      `${configurationType}|${projectId}`,
+      `${key}`,
       ScopeType.Default
     );
   }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,3 +15,8 @@ export interface IManifest {
   version?: string;
   cascades?: CascadeConfiguration;
 }
+
+export interface ICascadeSettings {
+  overrideOrgSettings?: boolean;
+  manifest?: IManifest;
+}

--- a/src/confighub/app.tsx
+++ b/src/confighub/app.tsx
@@ -1,6 +1,7 @@
 import * as SDK from 'azure-devops-extension-sdk';
 import * as React from 'react';
 import { useEffect } from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import ConfigView from './views/ConfigView';
 
 const App = () => {
@@ -8,7 +9,11 @@ const App = () => {
     SDK.notifyLoadSucceeded();
   }, []);
 
-  return <ConfigView />;
+  return (
+    <BrowserRouter>
+      <ConfigView />
+    </BrowserRouter>
+  );
 };
 
 export default App;

--- a/src/confighub/components/ProjectOverrides.tsx
+++ b/src/confighub/components/ProjectOverrides.tsx
@@ -1,0 +1,69 @@
+import { Button } from 'azure-devops-ui/Button';
+import { ScrollableList, IListItemDetails, ListSelection, ListItem, SimpleList } from "azure-devops-ui/List";
+import { ArrayItemProvider } from "azure-devops-ui/Utilities/Provider";
+import { Card } from "azure-devops-ui/Card";
+import {
+  CustomHeader,
+  HeaderTitle,
+  HeaderTitleArea,
+  HeaderTitleRow,
+  TitleSize,
+} from 'azure-devops-ui/Header';
+import { IStatusProps, Status, Statuses, StatusSize } from 'azure-devops-ui/Status';
+import * as React from 'react';
+import styled from 'styled-components';
+import { IStatus } from '../hooks/configstorage';
+import { ObservableValue } from "azure-devops-ui/Core/Observable";
+import { Toggle } from "azure-devops-ui/Toggle";
+
+interface IProjectOverridesProps {
+  isVisible: boolean;
+  toggle: ObservableValue<boolean>;
+  //onToggleClick: () => void | Promise<void>;
+}
+
+const HeaderSideContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  & > * {
+    margin: 0 1rem 0 1rem;
+  }
+`;
+const ProjectOverridesViewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-left: 1rem;
+  padding-right: 1rem;
+`;
+
+const ProjectOverrides = ({ isVisible, toggle }: IProjectOverridesProps) => {
+  if(isVisible == true)
+  {
+    return (
+      <ProjectOverridesViewContainer>
+        <Card className="flex-grow" >
+            Configure the JSON rules that drive how the cascading picklist would work. 
+            This is inherited from the Organization level unless overriden here.   
+        </Card>
+        <Table ariaLabel="Basic Table" columns={fixedColumns} />
+        <Toggle
+            onText={"Override Organization Cascading rules"}
+            offText={"Override Organization Cascading rules"}
+            checked={toggle}
+            onChange={(event, value) => (toggle.value = value)}
+        />
+      </ProjectOverridesViewContainer>
+    );
+  }
+  else
+  {
+    return (
+      <Card className="flex-grow" >
+          Configure the JSON rules that drive how the cascading picklist would work. This will be applied to
+          all Projects unless overriden at the Project level.   
+      </Card>);
+  }
+};
+
+export { ProjectOverrides, IProjectOverridesProps };

--- a/src/confighub/components/ProjectOverrides.tsx
+++ b/src/confighub/components/ProjectOverrides.tsx
@@ -46,7 +46,6 @@ const ProjectOverrides = ({ isVisible, toggle }: IProjectOverridesProps) => {
             Configure the JSON rules that drive how the cascading picklist would work. 
             This is inherited from the Organization level unless overriden here.   
         </Card>
-        <Table ariaLabel="Basic Table" columns={fixedColumns} />
         <Toggle
             onText={"Override Organization Cascading rules"}
             offText={"Override Organization Cascading rules"}

--- a/src/confighub/hooks/configstorage.ts
+++ b/src/confighub/hooks/configstorage.ts
@@ -102,14 +102,14 @@ function useConfigurationStorage(useProject: boolean = true, toggleValue: Observ
     setConfig(savedSettings.manifest);
   }
 
-  async function toggleHandler(override: boolean): Promise<void> {
-    console.log(`toggleHandler: Assigning toggle override flag to ${override} with useProject= ${useProject}`);
+  async function toggleHandler(allowOverride: boolean): Promise<void> {
+    console.log(`toggleHandler: Assigning toggle override flag to ${allowOverride} with useProject= ${useProject}`);
     setEditorOptions({
       selectOnLineNumbers: true,
-      readOnly: ((!override && useProject) || (!useProject && !override))
+      readOnly: !((allowOverride == true && useProject == true) || (useProject == false))
     });
 
-    setOverrideFlag(override);
+    setOverrideFlag(allowOverride);
   }
 
   useEffect(() => {
@@ -118,7 +118,6 @@ function useConfigurationStorage(useProject: boolean = true, toggleValue: Observ
 
       if(useProject == true)
       {
-        try{
         console.log('Retrieving project Id');
         
         const projectInfoService = await SDK.getService<IProjectPageService>(
@@ -126,10 +125,6 @@ function useConfigurationStorage(useProject: boolean = true, toggleValue: Observ
         );
         const project = await projectInfoService.getProject();
         projectId = project.id;        
-      } catch (error) {
-        console.log('TEST: Failed to retrieve project Id');
-        projectId = "000-000-000";
-      }
       }
       
       const manifestService = new ManifestService(projectId);
@@ -145,6 +140,14 @@ function useConfigurationStorage(useProject: boolean = true, toggleValue: Observ
         console.log(`Assigning overrideOrgSettings: ${settings.overrideOrgSettings}`);
         toggleValue.value = settings.overrideOrgSettings;
         setOverrideToggle(new ObservableValue<boolean>(settings.overrideOrgSettings));
+      }
+      else
+      {
+        if(useProject  == true)
+        {
+          toggleValue.value = false;
+          setOverrideToggle(new ObservableValue<boolean>(false));
+        }
       }
 
       if (manifest == null) {

--- a/src/confighub/hooks/configstorage.ts
+++ b/src/confighub/hooks/configstorage.ts
@@ -7,6 +7,9 @@ import {
   ManifestValidationService,
   ValidationErrorCode,
 } from '../../common/manifest.service';
+import { ConfigurationStorage } from '../../common/storage.service';
+import { ObservableValue } from "azure-devops-ui/Core/Observable";
+import { IManifest, ICascadeSettings } from '../../common/types';
 
 interface IStatus {
   status: boolean;
@@ -15,13 +18,21 @@ interface IStatus {
 
 const manifestValidationService = new ManifestValidationService();
 
-function useConfigurationStorage(): [
+function useConfigurationStorage(useProject: boolean = true, toggleValue: ObservableValue<boolean>): [
   string,
+  (boolean) => Promise<void>,
+  object,
   IStatus,
   (value: string) => void,
   () => Promise<void>
 ] {
   const [config, setConfig] = useState<Object>({});
+  const [editorOptions, setEditorOptions] = useState<Object>({
+    selectOnLineNumbers: true,
+    readOnly: false
+  });
+  const [overrideFlag, setOverrideFlag] = useState<boolean>();
+  const [overrideToggleControlValue, setOverrideToggle] = useState<ObservableValue<boolean>>(toggleValue);
   const [configText, setConfigText] = useState<string>('');
   const [status, setStatus] = useState<IStatus>({
     status: true,
@@ -30,6 +41,7 @@ function useConfigurationStorage(): [
 
   async function validateDraft(value: string): Promise<void> {
     try {
+      console.log('validateDraft: Validating draft settings.');
       const parsedConfig: Object = JSON.parse(value);
       const errors = await manifestValidationService.validate(parsedConfig);
       if (errors && errors.length > 0) {
@@ -50,7 +62,7 @@ function useConfigurationStorage(): [
         errors: [
           {
             code: ValidationErrorCode.SyntaxError,
-            description: 'Config syntax error',
+            description: `Config syntax error ${error}`,
           },
         ],
       });
@@ -58,6 +70,7 @@ function useConfigurationStorage(): [
   }
 
   const saveDraft = useCallback(function(value: string): void {
+    console.log('saveDraft: Saving settings as draft.');
     setConfigText(value);
     validateDraft(value);
   }, []);
@@ -66,24 +79,70 @@ function useConfigurationStorage(): [
     if (!status.status) {
       throw new Error(`${status.errors.map(error => error.description).join(';')}`);
     }
+    console.log('publishConfig: Saving settings.');
+    let projectId: string = null;
 
-    const projectInfoService = await SDK.getService<IProjectPageService>(
-      CommonServiceIds.ProjectPageService
-    );
-    const project = await projectInfoService.getProject();
-    const manifest = await new ManifestService(project.id).updateManifest(config);
-    setConfig(manifest);
-  }
-
-  useEffect(() => {
-    (async function() {
+    if(useProject == true)
+    {
       const projectInfoService = await SDK.getService<IProjectPageService>(
         CommonServiceIds.ProjectPageService
       );
       const project = await projectInfoService.getProject();
-      const manifestService = new ManifestService(project.id);
-      let manifest = await manifestService.getManifest();
+      projectId = project.id;
+    }
+    
+    //const manifest = await new ManifestService(projectId).updateManifest(config);
+    let settings: ICascadeSettings = { 
+        overrideOrgSettings: ((useProject) ? overrideFlag : false),
+        manifest: config
+      };
+
+    const savedSettings = await new ManifestService(projectId).updateConfigurationSettings(settings);
+
+    setConfig(savedSettings.manifest);
+  }
+
+  async function toggleHandler(override: boolean): Promise<void> {
+    console.log(`toggleHandler: Assigning toggle override flag to ${override}`);
+    setEditorOptions({
+      selectOnLineNumbers: true,
+      readOnly: (!override || (useProject == false))
+    });
+
+    setOverrideFlag(override);
+  }
+
+  useEffect(() => {
+    (async function() {
+      let projectId: string = null;
+
+      if(useProject == true)
+      {
+        console.log('Retrieving project Id');
+        const projectInfoService = await SDK.getService<IProjectPageService>(
+          CommonServiceIds.ProjectPageService
+        );
+        const project = await projectInfoService.getProject();
+        projectId = project.id;        
+      }
+      
+      const manifestService = new ManifestService(projectId);
+
+      console.log('useEffect: loading initial settings.');
+      //let manifest = await manifestService.getManifest();
+      let settings: ICascadeSettings = await manifestService.getConfigurationSettings();
+      let manifest: IManifest = null;
+
+      if(settings != null)
+      {
+        manifest = settings.manifest;
+        console.log(`Assigning overrideOrgSettings: ${settings.overrideOrgSettings}`);
+        toggleValue.value = settings.overrideOrgSettings;
+        setOverrideToggle(new ObservableValue<boolean>(settings.overrideOrgSettings));
+      }
+
       if (manifest == null) {
+        console.log('Assigning defaultManifest');
         manifest = Object.assign({}, ManifestService.defaultManifest);
       }
 
@@ -91,7 +150,7 @@ function useConfigurationStorage(): [
     })();
   }, [saveDraft]);
 
-  return [configText, status, saveDraft, publishConfig];
+  return [configText, toggleHandler, editorOptions, status, saveDraft, publishConfig];
 }
 
 export { useConfigurationStorage, IStatus };

--- a/src/confighub/hooks/configstorage.ts
+++ b/src/confighub/hooks/configstorage.ts
@@ -103,10 +103,10 @@ function useConfigurationStorage(useProject: boolean = true, toggleValue: Observ
   }
 
   async function toggleHandler(override: boolean): Promise<void> {
-    console.log(`toggleHandler: Assigning toggle override flag to ${override}`);
+    console.log(`toggleHandler: Assigning toggle override flag to ${override} with useProject= ${useProject}`);
     setEditorOptions({
       selectOnLineNumbers: true,
-      readOnly: (!override || (useProject == false))
+      readOnly: ((!override && useProject) || (!useProject && !override))
     });
 
     setOverrideFlag(override);
@@ -118,12 +118,18 @@ function useConfigurationStorage(useProject: boolean = true, toggleValue: Observ
 
       if(useProject == true)
       {
+        try{
         console.log('Retrieving project Id');
+        
         const projectInfoService = await SDK.getService<IProjectPageService>(
           CommonServiceIds.ProjectPageService
         );
         const project = await projectInfoService.getProject();
         projectId = project.id;        
+      } catch (error) {
+        console.log('TEST: Failed to retrieve project Id');
+        projectId = "000-000-000";
+      }
       }
       
       const manifestService = new ManifestService(projectId);

--- a/src/confighub/views/ConfigView.tsx
+++ b/src/confighub/views/ConfigView.tsx
@@ -57,7 +57,7 @@ const ConfigView: React.FC<RouteComponentProps<any>> = (rcprops) => {
 
   async function onCascadeSettingsOverrideToggle(value: boolean, action: string)
   {
-    console.log('onCascadeSettingsOverrideToggle: Raisinng toggle value change.');
+    console.log('onCascadeSettingsOverrideToggle: Raising toggle value change.');
     await toggleHandler(value);
   }
 

--- a/src/confighub/views/ConfigView.tsx
+++ b/src/confighub/views/ConfigView.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import styled from 'styled-components';
 import { Header } from '../components/Header';
+import { ProjectOverrides } from '../components/ProjectOverrides';
 import { useConfigurationStorage } from '../hooks/configstorage';
 import { useExternalToast } from '../hooks/toast';
 import { FieldsTable, FieldTableItem } from '../components/FieldsTable';
 import { ArrayItemProvider } from 'azure-devops-ui/Utilities/Provider';
-import { useProjectPicklistsList } from '../hooks/projectfieldlist';
+import { useProjectPicklistsList,getFieldPicklistsList } from '../hooks/projectfieldlist';
+//import { enableConfigOverride } from '../hooks/enableConfigOverride';
+import { RouteComponentProps, withRouter } from "react-router";
+import { ObservableValue } from "azure-devops-ui/Core/Observable";
 
 const EditorContainer = styled.div`
   display: flex;
@@ -21,14 +25,46 @@ const ConfigViewContainer = styled.div`
   padding-right: 1rem;
 `;
 
-const EditorOptions = {
+/*const EditorOptions = {
   selectOnLineNumbers: true,
-};
+  readOnly: false
+};*/
 
-const ConfigView: React.FC = () => {
-  const [configText, status, saveDraft, publishConfig] = useConfigurationStorage();
+const overrideCascadesToggle = new ObservableValue<boolean>(false);
+
+//const ConfigView: React.FC = () => {
+const ConfigView: React.FC<RouteComponentProps<any>> = (rcprops) => {
+  let headerTitle: string = "";
+
+  //firstToggle.subscribe(enableConfigOverride)
+
+  let orglevel: number = Number(getUrlParams().get('orglevel'));
+  let allowOverride: boolean = false;
+
+  if(orglevel == 1)
+  {
+    headerTitle = "Cascading Lists Master Config";
+  }
+  else{
+    headerTitle = "Cascading Lists Project Config";
+    allowOverride = true;
+  }
+  const [configText, toggleHandler, EditorOptions, status, saveDraft, publishConfig] = useConfigurationStorage(allowOverride, overrideCascadesToggle);
   const showToast = useExternalToast();
-  const fields = useProjectPicklistsList();
+  const fields = getFieldPicklistsList(allowOverride);//useProjectPicklistsList();
+
+  overrideCascadesToggle.subscribe(onCascadeSettingsOverrideToggle);
+
+  async function onCascadeSettingsOverrideToggle(value: boolean, action: string)
+  {
+    console.log('onCascadeSettingsOverrideToggle: Raisinng toggle value change.');
+    await toggleHandler(value);
+  }
+
+  function getUrlParams(): URLSearchParams {
+    if (!rcprops.location.search) return new URLSearchParams();
+    return new URLSearchParams(rcprops.location.search);
+  }
 
   function editorDidMount(editor) {
     editor.getModel().updateOptions({ tabSize: 2 });
@@ -36,16 +72,19 @@ const ConfigView: React.FC = () => {
 
   async function onSaveButtonClick() {
     try {
+      console.log('onSaveButtonClick: Saving settings.');
       await publishConfig();
       await showToast('Configuration succesfully saved.', 2000);
     } catch (error) {
       await showToast(`${(error as Error).message}`, 2000);
     }
   }
-
+  console.log('ConfigView: Returning view container');
+  
   return (
     <ConfigViewContainer>
-      <Header title='Cascading Lists Config' onSaveClick={onSaveButtonClick} status={status} />
+      <Header title={headerTitle} onSaveClick={onSaveButtonClick} status={status} />
+      <ProjectOverrides toggle={overrideCascadesToggle} isVisible={allowOverride} />
       <EditorContainer>
         <MonacoEditor
           height='800'
@@ -64,4 +103,4 @@ const ConfigView: React.FC = () => {
   );
 };
 
-export default ConfigView;
+export default withRouter(ConfigView);

--- a/src/observer/index.ts
+++ b/src/observer/index.ts
@@ -11,6 +11,7 @@ import {
 import * as SDK from 'azure-devops-extension-sdk';
 import { CascadingFieldsService } from '../common/cascading.service';
 import { ManifestService } from '../common/manifest.service';
+import { IManifest } from '../common/types';
 
 SDK.init({
   applyTheme: true,
@@ -25,7 +26,13 @@ SDK.init({
     );
     const project = await projectInfoService.getProject();
     const manifestService = new ManifestService(project.id);
-    let manifest = await manifestService.getManifest();
+    //let manifest = await manifestService.getManifest();
+    let manifest: IManifest = null
+    let settings = await manifestService.getConfigurationSettings();
+    
+    if (settings != null)
+      manifest = settings.manifest;
+      
     if (manifest == null) {
       manifest = Object.assign({}, ManifestService.defaultManifest);
     }


### PR DESCRIPTION
Support added to specify master JSON mapping for cascading lists with switch option at the project level to override if/as needed.
Key used to store the JSON remains unchanged except for project level which is a concatenation of the main key with the project ID
Retrieving data assumes an empty Project key will be organization level setting. 
Assumption made for project level setting to exist for backward compatibility 