### PR TITLE
Fix docs and webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Config example:
 
 2. [Install tfx-cli](https://docs.microsoft.com/en-us/vsts/extend/publish/command-line?view=vsts)
     ```
-        npm install --global tfx-cli
+    npm install --global tfx-cli
     ```
 
 3. Install dev prerequisites
@@ -82,6 +82,8 @@ npm run package-dev
 ```
 
 Then install the extension.
+This only has to be done once.
+After installing the extension, additional changes will be served by webpack.
 
 Serve the extension locally:
 ```

--- a/README.md
+++ b/README.md
@@ -53,36 +53,39 @@ Config example:
 
 2. The values setup in the picklist and the values in the configuration must be an exact match. There is no validation to check or correct spelling mistakes in the values.
 
-## Get started with Extensions
+## Prerequisites
 
-Building and testing the extension requires following.
+1. [Download and install NodeJS](http://nodejs.org)
 
-1.  [Download and install NodeJS](http://nodejs.org 'NodeJS Website')
-2.  [Install tfx-cli](https://docs.microsoft.com/en-us/vsts/extend/publish/command-line?view=vsts)
+2. [Install tfx-cli](https://docs.microsoft.com/en-us/vsts/extend/publish/command-line?view=vsts)
+    ```
+        npm install --global tfx-cli
+    ```
 
-```
-npm i -g tfx-cli
-```
+3. Install dev prerequisites
+    ```
+    npm install
+    ```
 
-Install dev prerequisites
-
-```
-npm install
-```
-
-### Create vsix to deploy on test environment
+### Build the extension
 
 ```
-npm run build
+npm run build-release
+npm run package-release
 ```
 
 ### Run the extension server locally
-
-Execute following commands in two separate Command Prompts. Denote that in order to test extenstion locally, you need to have certificate and key in the project root called `private.crt` and `private.key`.
-
+First build and package the development version of the extension:
 ```
-npm run watch
-npm run serve-dev
+npm run build-dev
+npm run package-dev
+```
+
+Then install the extension.
+
+Serve the extension locally:
+```
+npm run start
 ```
 
 ### Publish the dev extension to marketplace

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "start": "webpack-dev-server --hot --progress --static ./ --port 44300 --https",
     "build-dev": "webpack --progress --config webpack.dev.config.js",
+    "build-release": "webpack --progress",
     "package-dev": "tfx extension create --manifest-globs azure-devops-extension.json --overrides-file configs/dev.json",
     "package-release": "tfx extension create --manifest-globs azure-devops-extension.json --overrides-file configs/release.json",
-    "build:release": "webpack --progress",
     "postbuild": "npm run package",
     "package": "tfx extension create --manifest-globs azure-devops-extension.json",
     "gallery-publish": "tfx extension publish --rev-version",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "Extenstion that allows to customize cascading picklists for Azure DevOps.",
   "private": true,
   "scripts": {
-    "start": "webpack-dev-server --hot --progress --static ./ --port 44300 --https",
+    "start": "webpack-dev-server --hot --progress --static ./ --port 44300 --https --config webpack.dev.config.js",
     "build-dev": "webpack --progress --config webpack.dev.config.js",
     "build-release": "webpack --progress",
     "package-dev": "tfx extension create --manifest-globs azure-devops-extension.json --overrides-file configs/dev.json",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -11,6 +11,7 @@ const observerConfig = {
   output: {
     filename: 'observer.js',
     path: path.resolve(__dirname, 'dist'),
+    publicPath: '/dist/'
   },
   devtool: 'source-map',
 
@@ -33,7 +34,7 @@ const observerConfig = {
     new HtmlWebpackPlugin({
       filename: 'observer.html',
     }),
-  ],
+  ]
 };
 
 const confighubConfig = {
@@ -42,6 +43,7 @@ const confighubConfig = {
   output: {
     filename: 'confighub.js',
     path: path.resolve(__dirname, 'dist'),
+    publicPath: '/dist/'
   },
   devtool: 'source-map',
 


### PR DESCRIPTION
- Change the `build:release` script to `build-release` for consistency with the other scripts
- Clarify the installation, building, and running locally parts of the README
- Fix webpack-dev-server not serving the right files when running locally