### PR TITLE
Enable the extension for the on-prem Server version

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -25,7 +25,7 @@
   },
   "targets": [
     {
-      "id": "Microsoft.VisualStudio.Services.Cloud"
+      "id": "Microsoft.VisualStudio.Services"
     }
   ],
   "repository": {


### PR DESCRIPTION
This enables the extension for the Server version of Azure DevOps. I confirmed this extension work in Azure DevOps Server 2022. I might be able to check older versions, but I don't have any of those environments readily available.